### PR TITLE
New environment_linux.sh common script. (untested)

### DIFF
--- a/build/build_linux.sh
+++ b/build/build_linux.sh
@@ -1,20 +1,7 @@
 #!/bin/bash
-
-# First run ./build/configure_linux.sh script to download all the necessary dependencies.
-
-# Boost and libtorrent versions:
-LIBTORRENT_VERSION="RC_1_0"
-BOOST_VERSION="1_58_0"
-
-
-# Set the exports
-export LIBTORRENT_LIBS="$HOME/LIBTORRENT_LIBS"
-export LIBTORRENT_ROOT="$LIBTORRENT_LIBS/libtorrent-$LIBTORRENT_VERSION"
-export BOOST_ROOT="$LIBTORRENT_LIBS/boost_$BOOST_VERSION"
-
-# Set the java home directories
-JDK_INCLUDE_1=$JAVA_HOME/include
-JDK_INCLUDE_2=$JAVA_HOME/include/linux
+# NOTE: run ./build/configure_linux.sh script to download/update all the necessary dependencies.
+source ./build/environment_linux.sh
+sanityCheck
 
 CXX=g++
 DEFINES="-DNDEBUG=1 -DBOOST_ASIO_SEPARATE_COMPILATION=1 -DTORRENT_USE_CLOCK_GETTIME=1 -DTORRENT_DISABLE_GEO_IP=1 -DTORRENT_NO_DEPRECATE=1 -DBOOST_ASIO_DISABLE_STD_CHRONO=1 -DBOOST_ASIO_HAS_BOOST_CHRONO=1 -DTORRENT_USE_OPENSSL=1"

--- a/build/configure_linux.sh
+++ b/build/configure_linux.sh
@@ -1,35 +1,40 @@
-# Boost and libtorrent versions:
-LIBTORRENT_VERSION="RC_1_0"
-BOOST_VERSION="1_58_0"
-
+#!/bin/bash
+source ./build/environment_linux.sh
+sanityCheck
 
 # Some setup
 sudo apt-get install libbz2-dev libssl1.0.0 libcrypto++9 subversion
-mkdir $HOME/LIBTORRENT_LIBS
-export LIBTORRENT_LIBS="$HOME/LIBTORRENT_LIBS"
-#export CXXFLAGS="-stdlib=libc++ -std=c++11 -O3 -I$BOOST_ROOT"
 
-# Download Libtorrent and Boost, and export the home folders
-cd $LIBTORRENT_LIBS
-wget -O boost_$BOOST_VERSION.tar.bz2 http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_$BOOST_VERSION.tar.bz2/download
-tar -xvf boost_$BOOST_VERSION.tar.bz2
+# Download BOOST to BOOST_ROOT folder.
+mkdir -p $BOOST_ROOT
+pushd $BOOST_ROOT/..
+wget -O boost_$BOOST_UNDERSCORED_VERSION.tar.bz2 http://sourceforge.net/projects/boost/files/boost/$BOOST_DOTTED_VERSION/boost_$BOOST_UNDERSCORED_VERSION.tar.bz2/download
+tar -xvf boost_$BOOST_UNDERSCORED_VERSION.tar.bz2
+popd
+
+# Download libtorrent to LIBTORRENT_ROOT
+mkdir -p $LIBTORRENT_ROOT
+mkdir -p $LIBTORRENT_LIBS
+pushd $LIBTORRENT_ROOT/..
 svn checkout svn://svn.code.sf.net/p/libtorrent/code/branches/$LIBTORRENT_VERSION libtorrent-$LIBTORRENT_VERSION
+popd
 
-# Set the exports
-export LIBTORRENT_ROOT="$LIBTORRENT_LIBS/libtorrent-$LIBTORRENT_VERSION"
-export BOOST_ROOT="$LIBTORRENT_LIBS/boost_$BOOST_VERSION"
-
-# Build boost and copy the .a files
-cd $BOOST_ROOT
+# Build BOOST and copy the .a files to LIBTORRENT_LIBS
+pushd $BOOST_ROOT
 sh ./bootstrap.sh
 rm -rf bin*
 rm -rf linux
 $BOOST_ROOT/b2 variant=release link=static --stagedir=linux stage cxxflags="-O2 -fPIC" --with-date_time --with-chrono --with-system --with-random --with-thread
 cp linux/lib/*.a $LIBTORRENT_LIBS
+popd
 
 # Build and copy the libtorrent .a files
-cd $LIBTORRENT_ROOT
+pushd $LIBTORRENT_ROOT
 $BOOST_ROOT/bjam toolset=gcc cxxflags="-O2 -fPIC" cflags="-fPIC" variant=release link=static deprecated-functions=off logging=none encryption=openssl boost=source
-sudo cp bin/gcc-4.8/release/boost-source/deprecated-functions-off/encryption-openssl/link-static/threading-multi/libtorrent.a $LIBTORRENT_LIBS/
+cp bin/gcc-$GCC_VERSION/release/boost-source/deprecated-functions-off/encryption-openssl/link-static/threading-multi/libtorrent.a $LIBTORRENT_LIBS/
+popd
 
 # Run the build_linux script....
+echo "If there were no errors building BOOST and libtorrent proceed now to execute:"
+echo "./build/build_linux.sh"
+echo ""

--- a/build/environment_linux.sh
+++ b/build/environment_linux.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+###############################################################################################################
+# environment_linux.sh: define variables, paths and common functions for configure_linux.sh and build_linux.sh
+###############################################################################################################
+
+export GCC_VERSION="4.8"
+
+# Boost Version
+export BOOST_VERSION_MAJOR="1"
+export BOOST_VERSION_MINOR="58"
+export BOOST_VERSION_BUILD="0"
+
+export BOOST_UNDERSCORED_VERSION="$BOOST_VERSION_MAJOR_$BOOST_VERSION_MINOR_$BOOST_VERSION_BUILD"
+export BOOST_DOTTED_VERSION="$BOOST_VERSION_MAJOR.$BOST_VERSION_MINOR.$BOOST_VERSION_BUILD"
+
+# Libtorrent version
+export LIBTORRENT_VERSION="RC_1_0"
+
+# Source Paths for BOOST and libtorrent
+export BOOST_ROOT="$HOME/src/boost_$BOOST_UNDERSCORED_VERSION"
+export LIBTORRENT_ROOT="$HOME/src/libtorrent-$LIBTORRENT_VERSION"
+
+# (All binary libraries required from BOOST and libtorrent will go here for linking)
+export LIBTORRENT_LIBS="$HOME/libs/LIBTORRENT_LIBS"
+
+# Java/jni include folders.
+export JDK_INCLUDE_1=$JAVA_HOME/include
+export JDK_INCLUDE_2=$JAVA_HOME/include/linux
+
+###############################################################################################################
+
+function printEnvironment() {
+  echo HOME=$HOME
+  echo GCC_VERSION=$GCC_VERSION
+  echo ""
+  echo BOOST_UNDERSCORED_VERSION=$BOOST_UNDERSCORED_VERSION
+  echo BOOST_DOTTED_VERSION=$BOOST_DOTTED_VERSION
+  echo ""
+  echo LIBTORRENT_VERSION=$LIBTORRENT_VERSION
+  echo ""
+  echo BOOST_ROOT=$BOOST_ROOT
+  echo LIBTORRENT_ROOT=$LIBTORRENT_ROOT
+  echo LIBTORRENT_LIBS=$LIBTORRENT_LIBS
+  echo ""
+  echo JAVA_HOME=$JAVA_HOME
+  echo JDK_INCLUDE_1=$JAVA_HOME/include
+  echo JDK_INCLUDE_2=$JAVA_HOME/include/linux
+  echo ""
+  echo CXXFLAGS=$CXXFLAGS
+}
+
+function enterToContinueOrAbort() {
+  echo "(Press [Enter] to continue or Ctrl-c to abort)"
+  echo ""
+  read
+}
+
+function sanityCheck() {
+  printEnvironment
+  echo "Make sure the environment variables above are correct before proceeding forward."
+  enterToContinueOrAbort
+}


### PR DESCRIPTION
- environment_linux.sh defines commons environment variables and
  functions used by configure_linux.sh and build_linux.sh
- Made sure to not put source folders ($BOOST_ROOT, $LIBTORRENT_ROOT)
  inside $LIBTORRENT_LIBS, that folder is only meant for binary files.
- Source folders go inside "~/src/""
  e.g.
  - "~/src/boost_1_58_0"
  - "~/src/libtorrent_RC_1_0"
- $LIBTORRENT_LIBS folder goes inside ~/libs/
  eg. "~/libs/LIBTORRENT_LIBS"
